### PR TITLE
I've audited our project's dependencies and confirmed that we no long…

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e",
-    "postinstall": "ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points"
+    "e2e": "ng e2e"
   },
   "engines": {
     "node": "18.x"


### PR DESCRIPTION
…er need the `ngcc` postinstall script. This is because all of our Angular packages are modern and don't require the older compatibility compiler. I've removed the script to speed up our installation process and align with current Angular best practices. The project builds successfully without it.