### PR TITLE
feat: configure vercel deployment settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "cosqol-dashboard",
       "version": "0.0.0",
-      "hasInstallScript": true,
       "dependencies": {
         "@angular/animations": "^15.2.0",
         "@angular/common": "^15.2.0",

--- a/vercel.json
+++ b/vercel.json
@@ -15,5 +15,8 @@
       "dest": "/index.html"
     }
   ],
-  "buildCommand": "npm run build"
+  "buildCommand": "npm run vercel-build",
+  "engines": {
+    "node": "18.x"
+  }
 }


### PR DESCRIPTION
This commit configures the Vercel deployment settings in vercel.json.

- Sets the build command to `npm run vercel-build`.
- Explicitly sets the Node.js version to `18.x`.
- The output directory is already correctly configured via the `distDir` property.