### PR TITLE
Fix: Use @vercel/static-build for Vercel deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,18 @@
 {
   "version": 2,
   "builds": [
-    { "src": "angular.json", "use": "@vercel/angular" }
+    {
+      "src": "package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "dist/dashboard"
+      }
+    }
   ],
   "routes": [
-    { "src": "/.*", "dest": "/index.html" }
+    {
+      "src": "/(.*)",
+      "dest": "/index.html"
+    }
   ]
 }


### PR DESCRIPTION
The `@vercel/angular` builder is no longer published on the npm registry, causing deployment failures.

This commit updates the `vercel.json` configuration to use the `@vercel/static-build` builder, which is the correct and current method for deploying Angular applications to Vercel.

The configuration has been updated to correctly point to the project's build output directory.